### PR TITLE
신텍스 에러 수정.

### DIFF
--- a/src/spaceone/identity/connector/kbfg_connector.py
+++ b/src/spaceone/identity/connector/kbfg_connector.py
@@ -88,8 +88,8 @@ class KbfgConnector(BaseConnector):
         # resultCode == S200.000
         r2 = r.json()
 
-        if r2.resultCode != "S200.000":
-            _LOGGER.debug(f'KbfgConnector return code : {r2.resultCode}')
+        if r2['resultCode'] != 'S200.000':
+            _LOGGER.debug(f'KbfgConnector return code : {r2["resultCode"]}')
             raise ERROR_INVALID_CREDENTIALS()
 
         user = r2['user']


### PR DESCRIPTION
r 변수로 받은 리스폰스 객체를
json으로 변형하여 r2 변수로 사용하는데,
변수 호출을 리스폰스 객체처럼 신텍스 에러가 나게 잘못 호출하고 있는 부분이 있어서 수정하였습니다.